### PR TITLE
update mip-askad.js

### DIFF
--- a/mip-askad/mip-askad.js
+++ b/mip-askad/mip-askad.js
@@ -62,7 +62,8 @@ define(function (require) {
             mipcallList.push(callback)
         }else {
             mipLoadingJs  = true;
-            var allurl = ["//ip.120ask.com/lt?js=m.120ask.com&r=1470735643","//scws.120ask.com/scws?t=js&content="+content,"//m.120ask.com/pub/js/x_m_none_jquery.js"];
+            var timestamp = ( new Date()).valueOf();
+            var allurl = ["//ip.120ask.com/lt?js=m.120ask.com&r="+timestamp,"//scws.120ask.com/scws?t=js&content="+content,"//m.120ask.com/pub/js/x_m_none_jquery.js"];
             var calbacklen = 3;
 
             for(var i = 0; i< allurl.length; i++) {


### PR DESCRIPTION
因调用ip.120ask.com需要传随机字符串，而现在却是传的固定参数，所以奖固定参数改为时间戳。