### PR TITLE
修复分享组件在微信打开的样式问题

### DIFF
--- a/mip-share/mip-share.less
+++ b/mip-share/mip-share.less
@@ -127,7 +127,7 @@
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.6) url(//m.baidu.com/se/static/pmd/pmd/share/images/wxtips.png) right 10px top 10px no-repeat;
-    background-size: 150px 150px;
+    background-size: 50%;
 }
 
 

--- a/mip-share/mip-share.less
+++ b/mip-share/mip-share.less
@@ -126,7 +126,8 @@
     z-index: 999;
     width: 100%;
     height: 100%;
-    background: rgba(0, 0, 0, 0.6) url(//m.baidu.com/se/static/pmd/pmd/share/images/wxtips.png) right 32px top 10px/50% no-repeat;
+    background: rgba(0, 0, 0, 0.6) url(//m.baidu.com/se/static/pmd/pmd/share/images/wxtips.png) right 10px top 10px no-repeat;
+    background-size: 150px 150px;
 }
 
 


### PR DESCRIPTION
fixes #201 
修复后样式正常：
![d783d491b6861a70e8c8d266052eb399](https://cloud.githubusercontent.com/assets/8498677/21173129/2da23c60-c211-11e6-9f13-e5ca675c846f.png)
