### PR TITLE
修改组件在mip-cache下logo跳转失效问题

### DIFF
--- a/mip-nav-slidedown/mip-nav-slidedown.js
+++ b/mip-nav-slidedown/mip-nav-slidedown.js
@@ -23,7 +23,7 @@ define(function (require) {
         var $this = $(me);
         var id = $this.data('id');
         var showBrand = $this.data('showbrand') !== '0';
-        var brandHref = $this.data('brandhref') || '/';
+        var brandHref = $this.data('brandhref') || '#';
         var $ulNav = $this.find('#' + id);
         var $container = $('<div></div>');
         var $btnWrap = '<div class="navbar-header">'


### PR DESCRIPTION
`href=“/”`为绝对地址，在mip-cache下跳转有问题。