### PR TITLE
增加readmore组件

### DIFF
--- a/mip-readmore/README.md
+++ b/mip-readmore/README.md
@@ -1,0 +1,46 @@
+# mip-readmore
+
+mip-readmore 组件说明
+
+标题|内容
+----|----
+类型|文章类
+支持布局|container
+所需脚本|http://mipcache.bdstatic.com/static/v1/mip-readmore/mip-readmore.js
+
+## 示例
+
+### 基本用法
+```html
+<mip-readmore maxHeight="600" pageClass="paging" id="readmore" imgHref="http://m.cndzys.com/jiankangtoutiao/tongyong/">
+    自定义内容，可以嵌套其他组件
+</mip-readmore>
+```
+
+## 属性
+
+### maxHeight
+
+说明：设置文章允许的最大高度，超过即隐藏
+必选项：是
+类型：integer
+取值范围：>0
+单位：px
+
+### pageClass
+
+说明：设置分页class，如果分页class内为空则使用隐藏功能，如果不为空则不启用该组件
+必选项：是
+类型：string
+
+### id
+
+说明：设置组件id 以便使用dom元素
+必选项：是
+类型：string
+
+### imgHref
+
+说明：为文章内提供提供一个a标签
+必选项：否
+类型：string

--- a/mip-readmore/mip-readmore.js
+++ b/mip-readmore/mip-readmore.js
@@ -1,0 +1,39 @@
+/**
+ * @file mip-readmore 组件
+ * @author
+ */
+define(function (require) {
+    var $ = require('zepto');
+    var customElement = require('customElement').create();
+
+    /**
+     * 构造元素，只会运行一次
+     */
+    customElement.prototype.build = function () {
+        var element = this.element;
+        var maxHeight = $(element).attr('maxHeight');
+        var pageClass = '.' + $(element).attr('pageClass');
+        var imgHref = $(element).attr('imgHref');
+        var thisId = $(element).attr('id');
+        var thisHeight = element.scrollHeight;
+        if (thisHeight > maxHeight && $(pageClass).contents().length === 0) {
+            $(element).css({height: maxHeight + 'px', overflow: 'hidden'});
+            $(pageClass).append('<a on="tap:' + thisId + '.read_more(show)">点击阅读全文</a>');
+            if (imgHref) {
+                $(element).children('mip-img').wrap('<a target="_blank" href="' + imgHref + '></a>');
+            }
+        }
+        this.addEventAction('read_more', function (event, str) {
+            if (str === 'show') {
+                $(element).css({height: '', overflow: 'auto'});
+                $(pageClass).html('<a on="tap:' + thisId + '.read_more(hide)">折叠收起</a>');
+            }
+            if (str === 'hide') {
+                $(element).css({height: maxHeight + 'px', overflow: 'hidden'});
+                $(pageClass).html('<a on="tap:' + thisId + '.read_more(show)">展开更多</a>');
+            }
+        });
+    };
+
+    return customElement;
+});

--- a/mip-readmore/mip-readmore.less
+++ b/mip-readmore/mip-readmore.less
@@ -1,0 +1,7 @@
+/**
+ * @file mip-readmore样式文件
+ */
+
+mip-readmore {
+    // TODO
+}

--- a/mip-readmore/package.json
+++ b/mip-readmore/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "mip-readmore",
+    "version": "1.0.0",
+    "description": "为无分页文章提供超过长度隐藏操作，点击查看全文可展开。",
+    "contributors": [
+        {
+            "name": "gengxin",
+            "email": "137105161@qq.com"
+        }
+    ],
+    "engines": {
+        "mip": ">=1.1.0"
+    }
+}


### PR DESCRIPTION
+# mip-readmore
+
+mip-readmore 组件说明
+为无分页文章提供超过长度隐藏操作。
+
+标题|内容
+----|----
+类型|文章类
+支持布局|container
+所需脚本|http://mipcache.bdstatic.com/static/v1/mip-readmore/mip-readmore.js
+
+## 示例
+
+### 基本用法
+```html
+<mip-readmore maxHeight="600" pageClass="paging" id="readmore" imgHref="http://m.cndzys.com/jiankangtoutiao/tongyong/">
+    自定义内容，可以嵌套其他组件
+</mip-readmore>
+```
+
+## 属性
+
+### maxHeight
+
+说明：设置文章允许的最大高度，超过即隐藏
+必选项：是
+类型：integer
+取值范围：>0
+单位：px
+
+### pageClass
+
+说明：设置分页class，如果分页class内为空则使用隐藏功能，如果不为空则不启用该组件
+必选项：是
+类型：string
+
+### id
+
+说明：设置组件id 以便使用dom元素
+必选项：是
+类型：string
+
+### imgHref
+
+说明：为文章内提供提供一个a标签
+必选项：否
+类型：string