### PR TITLE
mip-semi-fixed修复初始化时高度计算问题

### DIFF
--- a/mip-semi-fixed/mip-semi-fixed.js
+++ b/mip-semi-fixed/mip-semi-fixed.js
@@ -106,6 +106,7 @@ define(function (require) {
 
         var self = this;
         var element = self.element;
+        offsetTop = util.rect.getElementOffset(element).top;
         if (fixedElement && fixedElement._fixedLayer && element.parentNode === fixedElement._fixedLayer) {
             return;
         }
@@ -121,7 +122,6 @@ define(function (require) {
 
         // iframe 中
         if (viewer.isIframed && util.platform.isIos()) {
-
             try {
                 var  wrapp = fixedElement._fixedLayer.querySelector('#' + element.id);
                 self.fixedContainer = wrapp.querySelector('div[mip-semi-fixed-container]');
@@ -153,11 +153,10 @@ define(function (require) {
             document.body.addEventListener('touchmove', function (event) {
                 onScroll.call(self, viewport);
             });
-
         }
 
         // 初始状态为 fixed 时
-        if (!util.platform.isIos() && element.offsetTop <= self.threshold) {
+        if (!util.platform.isIos() && offsetTop <= self.threshold) {
             if (self.container.className.indexOf(self.fixedClassNames) < 0) {
                 self.container.className += self.fixedClassNames;
             }
@@ -166,7 +165,7 @@ define(function (require) {
         }
         else if (util.platform.isIos() && viewer.isIframed
 
-                && element.offsetTop - viewport.getScrollTop() <= self.threshold) {
+                && offsetTop <= self.threshold) {
 
             util.css(this.fixedContainer.parentNode, {display: 'block'});
             util.css(this.fixedContainer, {opacity: 1});

--- a/mip-semi-fixed/package.json
+++ b/mip-semi-fixed/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mip-semi-fixed",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "滑动悬浮组件",
     "contributors": [
         {


### PR DESCRIPTION
旧代码获取的是element.offsetTop，对于position:absolute元素返回结果一直为0. 导致元素初始化贴顶计算失败。