### PR TITLE
fix: 优化 mip-sidebar 组件的预览代码

### DIFF
--- a/mip-sidebar/README.md
+++ b/mip-sidebar/README.md
@@ -71,6 +71,20 @@
         </li>
         <li>Nav item 5</li>
         <li>Nav item 6</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
+        <li>placeholder</li>
     </ul>
 </mip-sidebar>
 ```

--- a/mip-sidebar/README.md
+++ b/mip-sidebar/README.md
@@ -14,45 +14,30 @@
 
 ```html
 <header>
-    <div id="hamburger" class="mip-button" on="tap:sidebar.open">
-      <div id="logo" href="/">Open mip-sidebar</div>
-    </div>
+    <div id="logo" on="tap:sidebar.open">Open mip-sidebar</div>
 </header>
 <mip-sidebar 
-    id='sidebar'
+    id="sidebar"
     layout="nodisplay"
     class="mip-hidden">
     <ul>
-      <li>
-        <mip-link href="#">Home</mip-link>
-        <button class="mip-button" on="tap:sidebar.close"> X </button>
-      </li>
-      <li> Nav item 1</li>
-      <li>
-        <mip-fit-text width="220"
-            height="20"
-            layout="responsive"
-            max-font-size="24">
-          Nav item 2 - &lt;mip-fit-text&gt;
-        </mip-fit-text>
-      </li>
-      <li>
-        <mip-fit-text width="220"
-            height="20"
-            layout="responsive"
-            max-font-size="24">
-          Nav item 3 - &lt;mip-fit-text&gt; longer text
-        </mip-fit-text>
-      </li>
-      <li> Nav item 4 - Image
-        <mip-img class='mip-sidebar-image'
-            src="http://placeholder.qiniudn.com/100x50"
-            width="20"
-            height="20"
-            alt="an image"></mip-img>
-      </li>
-      <li> Nav item 5</li>
-      <li> Nav item 6</li>
+        <li>
+            <a href="https://www.mipengine.org/">MIP官网</a>
+            <button on="tap:sidebar.close"> X </button>
+        </li>
+        <li>Nav item 1</li>
+        <li>Nav item 2</li>
+        <li>Nav item 3</li>
+        <li>
+            Nav item 4 - Image
+            <mip-img
+                src="https://www.mipengine.org/favicon.ico"
+                width="32"
+                height="32"
+                alt="mipengine ico"></mip-img>
+        </li>
+        <li>Nav item 5</li>
+        <li>Nav item 6</li>
     </ul>
 </mip-sidebar>
 ```
@@ -61,46 +46,31 @@
 
 ```html
 <header>
-    <div id="hamburger" class="mip-button" on="tap:right-sidebar.open">
-      <div id="logo" href="/">Open mip-sidebar</div>
-    </div>
+    <div id="logo" on="tap:right-sidebar.open">Open mip-sidebar</div>
 </header>
 <mip-sidebar 
-    id='right-sidebar'
+    id="right-sidebar"
     layout="nodisplay"
     side="right"
     class="mip-hidden">
     <ul>
-      <li>
-        <mip-link href="#">Home</mip-link>
-        <button class="mip-button" on="tap:right-sidebar.close"> X </button>
-      </li>
-      <li> Nav item 1</li>
-      <li>
-        <mip-fit-text width="220"
-            height="20"
-            layout="responsive"
-            max-font-size="24">
-          Nav item 2 - &lt;mip-fit-text&gt;
-        </mip-fit-text>
-      </li>
-      <li>
-        <mip-fit-text width="220"
-            height="20"
-            layout="responsive"
-            max-font-size="24">
-          Nav item 3 - &lt;mip-fit-text&gt; longer text
-        </mip-fit-text>
-      </li>
-      <li> Nav item 4 - Image
-        <mip-img class='mip-sidebar-image'
-            src="http://placeholder.qiniudn.com/100x50"
-            width="20"
-            height="20"
-            alt="an image"></mip-img>
-      </li>
-      <li> Nav item 5</li>
-      <li> Nav item 6</li>
+        <li>
+            <a href="https://www.mipengine.org/">MIP官网</a>
+            <button on="tap:right-sidebar.close"> X </button>
+        </li>
+        <li>Nav item 1</li>
+        <li>Nav item 2</li>
+        <li>Nav item 3</li>
+        <li>
+            Nav item 4 - Image
+            <mip-img
+                src="https://www.mipengine.org/favicon.ico"
+                width="32"
+                height="32"
+                alt="mipengine ico"></mip-img>
+        </li>
+        <li>Nav item 5</li>
+        <li>Nav item 6</li>
     </ul>
 </mip-sidebar>
 ```


### PR DESCRIPTION
1. 删除无用/错误元素属性
2. 统一属性的双引号
3. 删除错误的 `<mip-fit-text>` 元素，1是因为没有引用该依赖代码，2是即使加载了也有问题。。。
4. 修复图片加载的 HTTPS 报警

---

不太敢大改，否则我会直接用 `<button on="tap:sidebar.open">点击打开左侧边栏</button>` 替换掉 `<div id="logo" on="tap:sidebar.open">Open mip-sidebar</div>` 。。。 😟 