### PR TITLE
feat: showmore按钮支持内部元素定制

### DIFF
--- a/src/mip-showmore/mip-showmore.js
+++ b/src/mip-showmore/mip-showmore.js
@@ -132,7 +132,6 @@ define(function (require) {
         } else {
             height = util.rect.getElementOffset(this.showBox).height;
         }
-
         // 如果高度大于阈值
         if (height > this.maxHeight) {
             util.css(this.showBox, {
@@ -192,7 +191,6 @@ define(function (require) {
         this.clickBtn.addEventListener('click', function () {
             showmore.toggle.apply(showmore);
         }, false);
-
 
     };
     // 点击时按钮添加class

--- a/src/mip-showmore/mip-showmore.js
+++ b/src/mip-showmore/mip-showmore.js
@@ -132,7 +132,7 @@ define(function (require) {
         } else {
             height = util.rect.getElementOffset(this.showBox).height;
         }
-        
+
         // 如果高度大于阈值
         if (height > this.maxHeight) {
             util.css(this.showBox, {
@@ -193,7 +193,7 @@ define(function (require) {
             showmore.toggle.apply(showmore);
         }, false);
 
-        
+
     };
     // 点击时按钮添加class
     Showmore.prototype.addClassWhenUnfold = function () {
@@ -284,7 +284,8 @@ define(function (require) {
         if (status === 'showOpen') {
             // v1.1.0 显示“展开”按钮
             if (clickBtn) {
-                clickBtn.innerText = clickBtn.dataset.opentext;
+                clickBtn.firstChild.textContent = clickBtn.dataset.opentext;
+                clickBtn.classList.remove('mip-showmore-open');
             }
             // v1.0.0 显示“展开”按钮
             this._changeBtnText({
@@ -296,9 +297,10 @@ define(function (require) {
         else {
             // v1.1.0显示“收起”按钮
             if (clickBtn) {
-                var opentext = clickBtn.innerText;
-                clickBtn.innerText = clickBtn.dataset.closetext || '收起';
+                var opentext = clickBtn.firstChild.textContent;
+                clickBtn.firstChild.textContent = clickBtn.dataset.closetext || '收起';
                 clickBtn.dataset.opentext = opentext;
+                clickBtn.classList.add('mip-showmore-open');
             }
 
             // v1.0.0 显示“收起”按钮

--- a/src/mip-showmore/mip-showmore.js
+++ b/src/mip-showmore/mip-showmore.js
@@ -199,26 +199,11 @@ define(function (require) {
         btnShowmore ? btnShowmore.classList.add('mip-showmore-btn-hide') : '';
     };
 
-    // 获取源按钮元素
-    Showmore.prototype.getTarget = function (id, target) {
-        if (!target || !id) {
-            return;
-        }
-        while (target.parentNode) {
-            var attrs = target.getAttribute('on');
-            if (attrs && attrs.indexOf("tap:" + id) === 0) {
-                return target;
-            }
-            target = target.parentNode
-        }
-        return target;
-    }
-
     // 高度阈值控制
     Showmore.prototype.toggle = function (event) {
         var me = this;
         var classList = this.ele.classList;
-        var clickBtn = this.getTarget(this.ele.id, event.target);
+        var clickBtn = event ? event.target : null;
 
         var opt = {};
         opt.aniTime = this.animateTime;
@@ -299,8 +284,7 @@ define(function (require) {
         if (status === 'showOpen') {
             // v1.1.0 显示“展开”按钮
             if (clickBtn) {
-                clickBtn.firstChild.textContent = clickBtn.dataset.opentext;
-                clickBtn.classList.remove('mip-showmore-open');
+                clickBtn.innerText = clickBtn.dataset.opentext;
             }
             // v1.0.0 显示“展开”按钮
             this._changeBtnText({
@@ -312,8 +296,8 @@ define(function (require) {
         else {
             // v1.1.0显示“收起”按钮
             if (clickBtn) {
-                var opentext = clickBtn.firstChild.textContent;
-                clickBtn.firstChild.textContent = clickBtn.dataset.closetext || '收起';
+                var opentext = clickBtn.innerText;
+                clickBtn.innerText = clickBtn.dataset.closetext || '收起';
                 clickBtn.dataset.opentext = opentext;
                 clickBtn.classList.add('mip-showmore-open');
             }

--- a/src/mip-showmore/mip-showmore.js
+++ b/src/mip-showmore/mip-showmore.js
@@ -198,13 +198,11 @@ define(function (require) {
         var btnShowmore = this.btn;
         btnShowmore ? btnShowmore.classList.add('mip-showmore-btn-hide') : '';
     };
-
     // 高度阈值控制
     Showmore.prototype.toggle = function (event) {
         var me = this;
         var classList = this.ele.classList;
         var clickBtn = event ? event.target : null;
-
         var opt = {};
         opt.aniTime = this.animateTime;
         if (this.showType === this.heightType[2]) {
@@ -281,10 +279,12 @@ define(function (require) {
         if (!status) {
             return;
         }
+        var openStyle = clickBtn.dataset.closestyle;
         if (status === 'showOpen') {
             // v1.1.0 显示“展开”按钮
             if (clickBtn) {
                 clickBtn.innerText = clickBtn.dataset.opentext;
+                openStyle && clickBtn.classList.remove(openStyle);
             }
             // v1.0.0 显示“展开”按钮
             this._changeBtnText({
@@ -300,6 +300,7 @@ define(function (require) {
                 clickBtn.innerText = clickBtn.dataset.closetext || '收起';
                 clickBtn.dataset.opentext = opentext;
                 clickBtn.classList.add('mip-showmore-open');
+                openStyle && clickBtn.classList.add(openStyle);
             }
 
             // v1.0.0 显示“收起”按钮

--- a/src/mip-showmore/mip-showmore.js
+++ b/src/mip-showmore/mip-showmore.js
@@ -198,11 +198,28 @@ define(function (require) {
         var btnShowmore = this.btn;
         btnShowmore ? btnShowmore.classList.add('mip-showmore-btn-hide') : '';
     };
+
+    // 获取源按钮元素
+    Showmore.prototype.getTarget = function (id, target) {
+        if (!target || !id) {
+            return;
+        }
+        while (target.parentNode) {
+            var attrs = target.getAttribute('on');
+            if (attrs && attrs.indexOf("tap:" + id) === 0) {
+                return target;
+            }
+            target = target.parentNode
+        }
+        return target;
+    }
+
     // 高度阈值控制
     Showmore.prototype.toggle = function (event) {
         var me = this;
         var classList = this.ele.classList;
-        var clickBtn = event ? event.target : null;
+        var clickBtn = this.getTarget(this.ele.id, event.target);
+
         var opt = {};
         opt.aniTime = this.animateTime;
         if (this.showType === this.heightType[2]) {

--- a/src/mip-showmore/mip-showmore.js
+++ b/src/mip-showmore/mip-showmore.js
@@ -299,7 +299,6 @@ define(function (require) {
                 var opentext = clickBtn.innerText;
                 clickBtn.innerText = clickBtn.dataset.closetext || '收起';
                 clickBtn.dataset.opentext = opentext;
-                clickBtn.classList.add('mip-showmore-open');
                 openStyle && clickBtn.classList.add(openStyle);
             }
 

--- a/src/mip-showmore/mip-showmore.js
+++ b/src/mip-showmore/mip-showmore.js
@@ -130,7 +130,7 @@ define(function (require) {
         if (this.showBox.style.height && this.showBox.style.height.match('px')) {
             height = getHeightUnfold(this.showBox);
         } else {
-            height = util.rect.getElementOffset(this.showBox).height;
+            height = getComputedStyle(this.showBox).height;
         }
         // 如果高度大于阈值
         if (height > this.maxHeight) {

--- a/src/mip-showmore/package.json
+++ b/src/mip-showmore/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mip-showmore",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "description": "mip点击显示更多组件:新增加按屏折叠，折叠边界渐变",
     "contributors": [
         {


### PR DESCRIPTION
问题
- 问题一：无法定制button icon；
- 问题二：details下使用mip-showmore不隐藏；

解决方案
- 问题一：增加一个属性`data-closestyle=""`   用于设置展开之后的样式，icon可以通过伪类来做，如 [demo](https://itoss.me/mip-test/src/mip-showmore/mip-showmore.html)
- 问题二：通过getComputedStyle获取高度。