### PR TITLE
create baidu developer stats plugin, 百度开发者中心需要的点击统计插件

### DIFF
--- a/src/mip-stats-baidu-developer/README.md
+++ b/src/mip-stats-baidu-developer/README.md
@@ -1,0 +1,29 @@
+# mip-stats-baidu-developer 百度开发者中心自定义页面访问数据统计插件
+
+在百度开发者中心添加统计组件，用于统计页面数据。
+
+标题|内容
+----|----
+类型| 通用
+支持布局|N/S
+所需脚本|https://mipcache.bdstatic.com/static/v1/mip-stats-baidu-developer/mip-stats-baidu-developer.js
+
+## 说明
+
+MIP百度开发者中心统计组件基于[百度开发者数据统计API](http://developer.baidu.com/collect/click)，目前只支持click事件追踪，其它事件暂不支持。
+
+## 示例
+
+根绝MIP规范，开发百度开发者中心需要的统计的插件，便于分析页面数据。
+
+百度开发者中心统计插件引入示例:
+
+<mip-stats-baidu-developer domain="https://developer.baidu.com/"></mip-stats-baidu-developer>
+
+## 属性
+
+### domain
+
+说明：domain，当前系统的域名，避免请求跨域 
+必填：是  
+格式：字符串

--- a/src/mip-stats-baidu-developer/mip-stats-baidu-developer.js
+++ b/src/mip-stats-baidu-developer/mip-stats-baidu-developer.js
@@ -1,0 +1,32 @@
+/**
+ * @file mip-stats-baidu-developer 组件
+ *
+ * @author tanyiming@baidu.com
+ */
+
+define(function(require) {
+
+    var $ = require('zepto');
+    var customElement = require('customElement').create();
+
+    customElement.prototype.createdCallback = function() {
+        var domain = this.element.getAttribute('domain');
+        domain = domain !== undefined && domain !== '' ? domain : 'https://developer.baidu.com/';
+        var api = domain + 'collect/click';
+        console.log(api);
+        $('a').click(function() {
+            var url = $(this).attr('href');
+            var logBean = { 'url': url, 'system': 'developer' };
+            $.ajax({
+                url: api,
+                contentType: 'application/json',
+                type: 'post',
+                cache: false,
+                data: JSON.stringify(logBean),
+                success: function(data) {}
+            });
+        });
+    };
+
+    return customElement;
+});

--- a/src/mip-stats-baidu-developer/package.json
+++ b/src/mip-stats-baidu-developer/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "mip-stats-baidu-developer",
+    "version": "1.0.0",
+    "description": "百度开发者中心自定义数据统计组件，用于统计页面链接点击情况",
+    "contributors": [
+        {
+            "name": "tanyiming",
+            "email": "tanyiming@baidu.com"
+        }
+    ],
+    "engines": {
+        "mip": ">=1.1.0"
+    }
+}


### PR DESCRIPTION
百度开发者中心按照MIP的规范实现了一个a标签点击统计插件，放到百度开发者中心Web技术页面，统计用户点击情况，统计为Web生态导流数据