### PR TITLE
fix: 修复 mip-vd-tabs 组件样式和文档示例

### DIFF
--- a/src/mip-vd-tabs/README.md
+++ b/src/mip-vd-tabs/README.md
@@ -14,7 +14,7 @@
 
 ### 等分固定标签页
 
-```
+```html
 <mip-vd-tabs>
     <section>
         <li>第一页</li>
@@ -30,7 +30,7 @@
 ```
 ### 横滑标签页
 
-```
+```html
 <mip-vd-tabs allow-scroll>
     <section>
         <li>第一季</li>
@@ -51,7 +51,7 @@
 
 ### 带下拉按钮的横滑标签页
 
-```
+```html
 <mip-vd-tabs allow-scroll toggle-more toggle-label="自定义文字">
     <section>
         <li>第一季</li>
@@ -68,7 +68,7 @@
 
 ### 底部标签页
 
-```
+```html
 <mip-vd-tabs allow-scroll type="bottom" current="3">
     <div>内容1</div>
     <div>内容2</div>
@@ -84,7 +84,7 @@
 ```
 
 ### 剧情展开标签页
-```
+```html
 <mip-vd-tabs
     type="episode"
     toggle-more

--- a/src/mip-vd-tabs/README.md
+++ b/src/mip-vd-tabs/README.md
@@ -93,7 +93,7 @@
     total="23"
     current="11"
     text-tpl="看第{{x}}集"
-    link-tpl="http://www.baidu.com/{{x}}/juji">
+    link-tpl="https://www.baidu.com/s?wd=老九门第{{x}}集">
 </mip-vd-tabs>
 ```
 

--- a/src/mip-vd-tabs/mip-vd-tabs.less
+++ b/src/mip-vd-tabs/mip-vd-tabs.less
@@ -139,7 +139,7 @@ mip-vd-tabs{
         color: #38f;
     }
 
-    .mip-vd-tabs .mip-vd-tabs-nav-toggle {
+    .mip-vd-tabs-nav-toggle {
         position: absolute;
         z-index: 9;
         top: 0;
@@ -162,7 +162,7 @@ mip-vd-tabs{
         }
     }
 
-    .mip-vd-tabs .mip-vd-tabs-nav-toggle-holder {
+    .mip-vd-tabs-nav-toggle-holder {
         display: inline-block;
         width: 29px;
         height: 1px;

--- a/src/mip-vd-tabs/package.json
+++ b/src/mip-vd-tabs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mip-vd-tabs",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "在网页中显示标签。标签页内元素较多时不建议使用,会影响页面性能。",   
     "author": {
         "name": "MIP authors",


### PR DESCRIPTION
1.  修复样式选择器嵌套问题，嵌套多个导致选择器失效了。。。
1. 给代码块添加了语言配置，方便在官网预览。
1. 修复了示例中的跳转链接死链，在官网上预览时死链多尴尬。
  