### PR TITLE
style: 优化 mip-sidebar 样式

### DIFF
--- a/src/mip-sidebar/mip-sidebar.js
+++ b/src/mip-sidebar/mip-sidebar.js
@@ -8,7 +8,6 @@
 define(function (require) {
     var customElement = require('customElement').create();
     var util = require('util');
-    var naboo = util.naboo;
 
     /**
      * [toggle 打开或关闭 sidebar 入口]
@@ -96,7 +95,6 @@ define(function (require) {
             const mask = document.createElement('div');
             mask.id = 'MIP-' + self.id.toUpperCase() + '-MASK';
             mask.className = 'MIP-SIDEBAR-MASK';
-            mask.style.display = 'block';
             mask.setAttribute('data-side', self.side);
 
             // 与mip-sidebar 同级dom
@@ -110,17 +108,14 @@ define(function (require) {
 
         self.maskElement.setAttribute('on', 'tap:' + self.id + '.close');
 
-        // 样式设置
         self.maskElement.style.display = 'block';
 
-        naboo.animate(self.maskElement, {
-            backgroundColor: 'rgba(0, 0, 0, .7)'
-        }, {
-            duration: 500
-        }).start(function () {
+        // 触发重绘
+        self.maskElement.offsetWidth;
+        self.maskElement.setAttribute('open', '');
+        setTimeout(function () {
             self.runing = false;
-            self.maskElement.setAttribute('show', '');
-        });
+        }, 500);
     }
 
     /**
@@ -129,15 +124,11 @@ define(function (require) {
     function closeMask() {
         var self = this;
         if (self.maskElement) {
-            self.maskElement.removeAttribute('show');
-            naboo.animate(self.maskElement, {
-                backgroundColor: 'rgba(0, 0, 0, 0)'
-            }, {
-                duration: 500
-            }).start(function () {
+            self.maskElement.removeAttribute('open');
+            setTimeout(function () {
                 self.maskElement.style.display = 'none';
                 self.runing = false;
-            });
+            }, 500);
         }
     }
 

--- a/src/mip-sidebar/mip-sidebar.less
+++ b/src/mip-sidebar/mip-sidebar.less
@@ -46,5 +46,10 @@ mip-sidebar[side][open] {
     background-image: none!important;
     background-color: rgba(0, 0, 0, 0);
     z-index: 9998!important;
+    -webkit-transition: background-color .5s .05s;
+            transition: background-color .5s .05s;
     display: none;
+}
+.MIP-SIDEBAR-MASK[open] {
+    background-color: rgba(0, 0, 0, .2);
 }

--- a/src/mip-sidebar/package.json
+++ b/src/mip-sidebar/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mip-sidebar",
-    "version": "1.1.7",
+    "version": "1.2.0",
     "description": "侧边栏组件，点击按钮，侧边栏滑入屏幕。",
     "contributors": [
         {


### PR DESCRIPTION
由于 mag-design 需要优化 mip-sidebar 的样式，单纯的一个遮罩层的 `<div>` 已经不能满足需要，现在如下调整：

1. 由透明度（`opacity`）切换成透明背景色（`rbga`）
1. 在遮罩层元素上添加 `data-side` 为当前侧边栏的方向
1. 在遮罩层元素上添加 `open` 属性来标识元素为显示状态，使用 JS 操作元素显示状态触发重绘后使用 CSS3 动画

待回归测试。