### PR TITLE
feat: 添加产出编译目录文件

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "mip-extensions",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "MIP 组件包括官方组件和开发者自定义组件，是用于定制站点页面功能的利器。",
   "main": "index.js",
   "directories": {
     "doc": "docs"
   },
   "scripts": {
-    "prebuild": "echo Hi Miper, Welcome to start compile!",
-    "build": "mip-extension-optimise ./src",
+    "build": "mip-extension-optimise ./src -o ./dist",
     "release": "gren release",
-    "postbuild": "echo Compile over, Have a nice day!"
+    "presite": "npm run build",
+    "site": "node tools/site.js"
   },
   "repository": {
     "type": "git",
@@ -20,13 +20,18 @@
     "MIP",
     "Extensions"
   ],
-  "author": "Jackson <smartfutureplayer@gmail.com>",
+  "author": "MIP <mip-support@baidu.com>",
+  "contributors": [
+    {
+      "name": "Jackson",
+      "email": "smartfutureplayer@gmail.com"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mipengine/mip-extensions/issues"
   },
   "homepage": "https://github.com/mipengine/mip-extensions#readme",
-  "dependencies": {},
   "devDependencies": {
     "github-release-notes": "^0.11.0",
     "mip-extension-optimizer": "^1.1.3"

--- a/tools/site.js
+++ b/tools/site.js
@@ -1,0 +1,58 @@
+/**
+ * @file 产出编译组件列表页面
+ * @author xuexb <fe.xiaowu@gmail.com>
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const dist = path.join(__dirname, '../dist');
+
+/**
+ * 版本号数据
+ *
+ * @type {Array}
+ * @example
+ *     [
+ *         {
+ *             name: 组件名,
+ *             version: 版本号
+ *         }
+ *     ]
+ */
+const versions = fs.readdirSync(dist)
+    .filter(name => fs.statSync(path.join(dist, name)).isDirectory())
+    .map(name => {
+        const version = fs.readdirSync(path.join(dist, name))[0];
+
+        return {
+            name,
+            version,
+            path: `${name}/${version}/${name}.js`
+        };
+    })
+    .map(item => `<li><a href="${item.path}" target="_blank">${item.name}@${item.version}</a></li>`);
+
+/**
+ * 生成 HTML 代码
+ *
+ * @type {string}
+ */
+const html = `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <title>MIP 组件列表</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <meta name="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=1.0">
+</head>
+<body>
+    <h1>MIP 组件列表</h1>
+    <ul>
+        ${versions.join('')}
+    </ul>
+</body>
+</html>`;
+
+fs.writeFileSync(path.join(dist, 'index.html'), html);


### PR DESCRIPTION
1. 添加产出编译组件目录文件功能`npm run site`
2. 修改作者信息
3. 修改编译命令（`npm run build`）产出路径，由 `src/dist` 修改为 `dist`