### PR TITLE
fix: 修复元素初始时状态

### DIFF
--- a/src/mip-semi-fixed/mip-semi-fixed.js
+++ b/src/mip-semi-fixed/mip-semi-fixed.js
@@ -143,7 +143,7 @@ define(function (require) {
             document.body.addEventListener('touchmove', function (event) {
                 onIframeScroll.call(self, viewport);
             });
-
+            onIframeScroll.call(self, viewport);
         }
         else {
             // 监听滚动事件和 touchmove 事件
@@ -153,6 +153,7 @@ define(function (require) {
             document.body.addEventListener('touchmove', function (event) {
                 onScroll.call(self, viewport);
             });
+            onScroll.call(self, viewport);
         }
 
         // 初始状态为 fixed 时

--- a/src/mip-semi-fixed/package.json
+++ b/src/mip-semi-fixed/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mip-semi-fixed",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "滑动悬浮组件",
     "contributors": [
         {


### PR DESCRIPTION
元素在初始时没有判断是否在可见区域，导致元素其实是显示的状态，优化为直接调用滚动判断的逻辑，优先判断可见状态并设置对应的显示状态。