### PR TITLE
'docs:百度联盟广告反屏蔽介绍分支的修改'

### DIFF
--- a/src/mip-ad/mip-baidu-wm-ext.md
+++ b/src/mip-ad/mip-baidu-wm-ext.md
@@ -18,8 +18,8 @@
 <mip-ad 
     type="baidu-wm-ext" 
     domain="dup.lovedword.com" 
-    token="3a1ec097f7cbf63edb0e7f98eff238f950e6ca0b29e67fe1103c">
-	<div id="3a1ec097f7cbf63edb0e7f98eff238f950e6ca0b29e67fe1103c"></div>
+    token="ezrwfrowb">
+	<div id="ezrwfrowb"></div>
 </mip-ad>
 ```
 ## 属性
@@ -58,6 +58,6 @@
 
 ## 注意事项
 
-- union 平台获取投放代码样例如下 &lt;script type="text/javascript" src="http://<font color="yellowgreen">dup.media.com</font>/<font color="red">3e34c098f4cff73cdb1f23c5adf722f740e7855275e13eef</font>.js"&gt;&lt;/script &gt;，绿色区域对应 MIP 投放代码 domain，红色区域对应 MIP 投放代码 `token` 和 `<div>` `id`。
+- union 平台获取投放代码样例如下 &lt;script type="text/javascript" src="http://<font color="yellowgreen">dup.media.com</font>/site/js/jy1c5t.js?<font color="red">ezrwf=rowb</font>"&gt;&lt;/script &gt;，绿色区域对应 MIP 投放代码 domain，红色区域<font color="red">去掉“=”</font>的结果（ezrwfrowb）为 MIP 投放代码 `token` 和 `<div>` `id`。
 
 - 联盟反屏蔽接入要求反屏蔽域名支持 HTTPS，可参见[接入说明文档](http://yingxiao.baidu.com/zhichi/knowledge/detail.action?channelId=4&classId=13484&knowledgeId=15198)。


### PR DESCRIPTION
**1、升级点** 
针对网盟的新反屏蔽投放方式，修改mip相对应的，接入反屏蔽投放的文档。
本次网盟的升级，将包含tuid的token部分，从path位置移到query位置，媒体反馈，找不到token。
因此升级mip接入文档，给媒体指导清楚，新投放如何取到token。

**2、影响范围** 
文档面向mip接入反屏蔽广告的媒体，具有指导意义。
