### PR TITLE
【免测】 fix: mip-accordion折叠组件，修复ios无痕浏览折叠节点不展开bug(mip1,mip2一起修复)

### DIFF
--- a/sample/mip-accordion/mip-accordion.html
+++ b/sample/mip-accordion/mip-accordion.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html mip>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <title>mip-accordion测试用例</title>
+    <link rel="stylesheet" type="text/css" href="https://c.mipcdn.com/static/v1/mip.css">
+    <link rel="canonical">
+    <style mip-custom>
+        h4 {
+            padding: 5px 10px;
+            background: #1dcdcd;
+        }
+
+        p {
+            padding: 0 10px;
+        }
+
+        mip-accordion .mip-accordion-content {
+            display: none !important;
+            overflow: hidden
+        }
+
+        mip-accordion .mip-accordion-content[aria-expanded="open"] {
+            display: block !important
+        }
+
+        mip-accordion section[expanded=open] .show-more {
+            display: none !important
+        }
+
+        mip-accordion section .show-more {
+            display: block
+        }
+
+        mip-accordion section .show-less {
+            display: none
+        }
+
+        mip-accordion section[expanded=open] .show-less {
+            display: block
+        }
+
+        /* 自定义样式 */
+    </style>
+</head>
+<body>
+<!-- 正文 -->
+<br>
+<h1>内容标题 + 手动</h1>
+<mip-accordion sessions-key="mip_2" type="manual" animatetime='0.24'>
+    <section>
+        <h4>下拉第一个</h4>
+        <p class="mip-accordion-content">我说你是人间的四月天；笑声点亮了四面风；轻灵在春的光艳中交舞着变。你是四月早天里的云烟，黄昏吹着风的软，星子在无意中闪，</p>
+    </section>
+    <section expanded="open">
+        <h4>下拉第二个</h4>
+        <p>细雨点洒在花前。那轻，那娉婷，你是，鲜妍百花的冠冕你戴着，你是天真，庄严，你是夜夜的月圆。</p>
+    </section>
+    <section>
+        <h4>下拉第三个</h4>
+        <mip-img layout="responsive" width="400" height="200" src="https://www.mipengine.org/static/img/sample_01.jpg"
+                 class="mip-accordion-content"></mip-img>
+    </section>
+</mip-accordion>
+<br>
+<br>
+<h1>内容标题</h1>
+<mip-accordion sessions-key="mip_1" animatetime='0.24'>
+    <section>
+        <h4>下拉第一个</h4>
+        <p class="mip-accordion-content">我说你是人间的四月天；笑声点亮了四面风；轻灵在春的光艳中交舞着变。你是四月早天里的云烟，黄昏吹着风的软，星子在无意中闪，</p>
+    </section>
+    <section expanded="open">
+        <h4>下拉第二个</h4>
+        <p>细雨点洒在花前。那轻，那娉婷，你是，鲜妍百花的冠冕你戴着，你是天真，庄严，你是夜夜的月圆。</p>
+    </section>
+    <section>
+        <h4>下拉第三个</h4>
+        <mip-img layout="responsive" width="400" height="200" src="https://www.mipengine.org/static/img/sample_01.jpg"
+                 class="mip-accordion-content"></mip-img>
+    </section>
+</mip-accordion>
+
+<br>
+<br>
+<h1>只展开一个</h1>
+<mip-accordion sessions-key="mip_4" expaned-limit>
+    <section>
+        <h4>下拉第一个</h4>
+        <p class="mip-accordion-content">我说你是人间的四月天；笑声点亮了四面风；轻灵在春的光艳中交舞着变。你是四月早天里的云烟，黄昏吹着风的软，星子在无意中闪，</p>
+    </section>
+    <section expanded>
+        <h4>下拉第二个</h4>
+        <p>细雨点洒在花前。那轻，那娉婷，你是，鲜妍百花的冠冕你戴着，你是天真，庄严，你是夜夜的月圆。</p>
+    </section>
+    <section>
+        <h4>下拉第三个</h4>
+        <mip-img
+            layout="responsive"
+            width="400"
+            height="200"
+            src="https://www.mipengine.org/static/img/sample_01.jpg" class="mip-accordion-content">
+        </mip-img>
+    </section>
+</mip-accordion>
+
+<script src="https://c.mipcdn.com/static/v1/mip.js"></script>
+<script src="https://c.mipcdn.com/static/v1/mip-accordion/mip-accordion.js"></script>
+</body>
+</html>

--- a/src/mip-accordion/mip-accordion.js
+++ b/src/mip-accordion/mip-accordion.js
@@ -117,16 +117,25 @@ define(function (require) {
     // 设置session storage
     function setSession(element, obj, expand) {
         var sessionsKey = 'MIP-' + element.getAttribute('sessions-key') + '-' + localurl;
-
-        var objsession = getSession(sessionsKey);
-        objsession[obj] = expand;
-        sessionStorage[sessionsKey] = JSON.stringify(objsession);
+        try {
+            var objsession = getSession(sessionsKey);
+            objsession[obj] = expand;
+            sessionStorage[sessionsKey] = JSON.stringify(objsession);
+        } catch (e) {
+          console.warn('用户无痕模式不支持 session');
+        }
     }
 
     // 获取sission
     function getSession(sessionsKey) {
-        var data = sessionStorage[sessionsKey];
-        return data ? JSON.parse(data) : {};
+        try {
+            var data = sessionStorage[sessionsKey];
+            return data ? JSON.parse(data) : {};
+        } catch (e) {
+
+            console.warn('用户无痕模式不支持 session');
+            return {};
+        }
     }
 
     /**


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
issue #1246 

修改了代码空格，只改了这里
![image](https://user-images.githubusercontent.com/27049480/44890559-55c5b300-ad0d-11e8-9cf1-48d8ea13d618.png)


**1、升级点** （清晰准确的描述升级的功能点）

ios 的 Safari 无痕浏览下 折叠组件功能正常（只在设置storage时加了个判断，保证无痕下不设置storage）

**2、影响范围** （描述该需求上线会影响什么功能）

无

**3、自测 checklist**

ios 的 Safari 无痕浏览下 折叠组件功能正常

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [x] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [x] 是否覆盖了手百

温馨提示：非 mip-extensions 仓库的组件请在[组件平台](https://www.mipengine.org/platform/mip#/)提交，否则一律打回；
