### PR TITLE
fixed: 修复医疗广告页底部 placeholder 高度获取不正确的问题

### DIFF
--- a/src/mip-custom/dom.js
+++ b/src/mip-custom/dom.js
@@ -211,7 +211,14 @@ define(function (require) {
 
                 if (zIndex >= maxzIndex) {
                     maxzIndex = zIndex;
-                    fixedElement.setPlaceholder(getCss(res.element, 'height') - excr);
+                    var now = Date.now();
+                    var timer = setInterval(function () {
+                        var height = getCss(res.element, 'height');
+                        if (height > 0 || Date.now() - now > 8000) {
+                            clearInterval(timer);
+                        }
+                        fixedElement.setPlaceholder(height - excr);
+                    }, 16);
                 }
             }
         });
@@ -305,7 +312,7 @@ define(function (require) {
      */
     function getConfigScriptElement(elem) {
         if (!elem) {
-            return;  
+            return;
         }
         return elem.querySelector('script[type="application/json"]');
     }
@@ -333,10 +340,10 @@ define(function (require) {
         var me = this;
         this.placeholder.classList.add('fadeout');
         // 占位符增加淡出效果
-        this.placeholder.addEventListener("transitionend", function() {
+        this.placeholder.addEventListener('transitionend', function () {
             me.placeholder.remove();
         }, false);
-        this.placeholder.addEventListener("webkitTransitionend", function() {
+        this.placeholder.addEventListener('webkitTransitionend', function () {
             me.placeholder.remove();
         }, false);
     }


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）

只要 mip 页面中的任何组件有异步渲染或者异步操作的过程，都会导致 mip-custom 获取不到动态插入的组件的高度

**2、影响范围** （描述该需求上线会影响什么功能）

所有医疗的 mip 结果都被遮住了底部的部分内容

**3、需要覆盖的场景和case**
- [x] 是否覆盖了sf打开mip页
- [x] 是否验证了极速服务mip页面效果

**4、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [x] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [x] 是否覆盖了手百

温馨提示：非 mip-extensions 仓库的组件请在[组件平台](https://www.mipengine.org/platform/mip#/)提交，否则一律打回；
