### PR TITLE
fix: 修改折叠组件在ios手机上文字内容透出的问题

### DIFF
--- a/src/mip-showmore/mip-showmore.less
+++ b/src/mip-showmore/mip-showmore.less
@@ -5,7 +5,7 @@
 mip-showmore {
     visibility: hidden;
     overflow: hidden;
-    transform: translateZ(0);
+    // transform: translateZ(0);
     .mip-showmore {
         &-originalhtml,
         &-btnhide,


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
[#1318](https://github.com/mipengine/mip-extensions/issues/1318)

**1、升级点** （清晰准确的描述升级的功能点）
   IOS 手百合作页折叠组件文字透出
**2、影响范围** （描述该需求上线会影响什么功能）
 IOS 手百医疗合作页
**3、自测 checklist**
  1. 不同资源方的合作页折叠效果
  2. 不同手机和浏览器合作页折叠效果

**4、需要覆盖的场景和case**
- [x] 是否覆盖了sf打开mip页
- [x] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [x] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [x] 是否覆盖了手百

温馨提示：非 mip-extensions 仓库的组件请在[组件平台](https://www.mipengine.org/platform/mip#/)提交，否则一律打回；
