### PR TITLE
全屏广告设置其容器padding为0

### DIFF
--- a/src/mip-custom/dom.js
+++ b/src/mip-custom/dom.js
@@ -185,6 +185,11 @@ define(function (require) {
         var customNode = createCustomNode(html, customTag);
         var itemNode = document.createElement('div');
         itemNode.setAttribute('mip-custom-item', len);
+        // 如果定制化组件属性有 no-padding 则把它的容器设置为 no-padding
+        // 组件属性 no-padding 必须设置一个值，哪怕是""，不然会被remove
+        if (customNode.hasAttribute('no-padding')) {
+            itemNode.classList.add('no-padding');
+        }
         // XXX work around: 由于需要在template渲染后把渲染结果插入到itemNode，container里面，
         // 只能把这些参数绑定在 customNode 里传给render.then中，通过res.element.itemNode获取
         customNode.itemNode = itemNode;

--- a/src/mip-custom/mip-custom.less
+++ b/src/mip-custom/mip-custom.less
@@ -28,6 +28,9 @@ mip-custom {
 			padding-bottom: 10px;
 		}
 	}
+	.no-padding {
+		padding: 0!important;
+	}
 	.mip-custom-placeholder {
 		min-height: 300px;
 		padding-top: 13px;


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**
#1322 

**1、升级点** （清晰准确的描述升级的功能点）
全屏广告设置其容器padding为0

**2、影响范围** （描述该需求上线会影响什么功能）
线上没有影响，广告数据暂未上线

**3、自测 checklist**
本地mock了common服务，自测通过

**4、需要覆盖的场景和case**
- [ ] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
- [ ] 是否覆盖了ios系统手机
- [ ] 是否覆盖了安卓系统手机
- [ ] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [ ] 是否覆盖了手百

温馨提示：非 mip-extensions 仓库的组件请在[组件平台](https://www.mipengine.org/platform/mip#/)提交，否则一律打回；
